### PR TITLE
[READY] Remove iostream workaround

### DIFF
--- a/cpp/ycm/ClangCompleter/ClangHelpers.cpp
+++ b/cpp/ycm/ClangCompleter/ClangHelpers.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 Google Inc.
+// Copyright (C) 2013-2018 ycmd contributors
 //
 // This file is part of ycmd.
 //
@@ -17,14 +17,13 @@
 
 #include "ClangHelpers.h"
 #include "ClangUtils.h"
-#include "Utils.h"
-#include "UnsavedFile.h"
 #include "Location.h"
 #include "Range.h"
 #include "PythonSupport.h"
+#include "UnsavedFile.h"
+#include "Utils.h"
 
 #include <unordered_map>
-#include <iostream>
 #include <utility>
 
 using std::unordered_map;

--- a/cpp/ycm/ClangCompleter/CompilationDatabase.h
+++ b/cpp/ycm/ClangCompleter/CompilationDatabase.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2011, 2012 Google Inc.
+// Copyright (C) 2011-2018 ycmd contributors
 //
 // This file is part of ycmd.
 //
@@ -18,18 +18,11 @@
 #ifndef COMPILATIONDATABASE_H_ZT7MQXPG
 #define COMPILATIONDATABASE_H_ZT7MQXPG
 
-/*
- * iostream is included because there's a bug with python
- * earlier than 2.7.12 and 3.5.3 on OSX and FreeBSD.
- * When either no one else is using earlier versions of python
- * or ycmd drops support for those, this include statement can be removed.
- */
-#include <iostream>
-#include <vector>
-#include <string>
+#include <clang-c/CXCompilationDatabase.h>
 #include <mutex>
 #include <pybind11/pybind11.h>
-#include <clang-c/CXCompilationDatabase.h>
+#include <string>
+#include <vector>
 
 namespace YouCompleteMe {
 

--- a/cpp/ycm/Word.cpp
+++ b/cpp/ycm/Word.cpp
@@ -18,7 +18,7 @@
 #include "CharacterRepository.h"
 #include "CodePoint.h"
 #include "Word.h"
-#include <iostream>
+
 #include <string>
 
 namespace YouCompleteMe {

--- a/cpp/ycm/benchmarks/IdentifierCompleter_bench.cpp
+++ b/cpp/ycm/benchmarks/IdentifierCompleter_bench.cpp
@@ -15,12 +15,13 @@
 // You should have received a copy of the GNU General Public License
 // along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "benchmark/benchmark_api.h"
 #include "BenchUtils.h"
 #include "CandidateRepository.h"
 #include "CharacterRepository.h"
 #include "CodePointRepository.h"
 #include "IdentifierCompleter.h"
+
+#include <benchmark/benchmark_api.h>
 
 namespace YouCompleteMe {
 

--- a/cpp/ycm/benchmarks/PythonSupport_bench.cpp
+++ b/cpp/ycm/benchmarks/PythonSupport_bench.cpp
@@ -15,21 +15,19 @@
 // You should have received a copy of the GNU General Public License
 // along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "benchmark/benchmark_api.h"
 #include "BenchUtils.h"
 #include "CandidateRepository.h"
 #include "CharacterRepository.h"
 #include "CodePointRepository.h"
-// iostream is included because of a bug with Python earlier than 2.7.12
-// and 3.5.3 on OSX and FreeBSD.
-#include <iostream>
 #include "PythonSupport.h"
+
+#include <benchmark/benchmark_api.h>
 
 namespace YouCompleteMe {
 
 class PythonSupportFixture : public benchmark::Fixture {
 public:
-  void SetUp( const benchmark::State& state ) {
+  void SetUp( const benchmark::State& ) {
     CodePointRepository::Instance().ClearCodePoints();
     CharacterRepository::Instance().ClearCharacters();
     CandidateRepository::Instance().ClearCandidates();

--- a/cpp/ycm/benchmarks/main.cpp
+++ b/cpp/ycm/benchmarks/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 ycmd contributors
+// Copyright (C) 2017-2018 ycmd contributors
 //
 // This file is part of ycmd.
 //
@@ -15,12 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "benchmark/benchmark_api.h"
-// iostream is included because of a bug with Python earlier than 2.7.12
-// and 3.5.3 on OSX and FreeBSD.
-#include <iostream>
+#include <benchmark/benchmark_api.h>
 #include <pybind11/embed.h>
-
 
 int main( int argc, char** argv ) {
   pybind11::scoped_interpreter guard{};

--- a/cpp/ycm/tests/Candidate_test.cpp
+++ b/cpp/ycm/tests/Candidate_test.cpp
@@ -15,12 +15,11 @@
 // You should have received a copy of the GNU General Public License
 // along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
 #include "Candidate.h"
 #include "Result.h"
 
-#include <iostream>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 using ::testing::Not;
 

--- a/cpp/ycm/tests/Word_test.cpp
+++ b/cpp/ycm/tests/Word_test.cpp
@@ -23,7 +23,6 @@
 #include <array>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
-#include <iostream>
 
 using ::testing::TestWithParam;
 using ::testing::ValuesIn;

--- a/cpp/ycm/tests/main.cpp
+++ b/cpp/ycm/tests/main.cpp
@@ -1,5 +1,22 @@
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
+// Copyright (C) 2018 ycmd contributors
+//
+// This file is part of ycmd.
+//
+// ycmd is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// ycmd is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <pybind11/embed.h>
 
 int main( int argc, char **argv ) {
@@ -8,4 +25,3 @@ int main( int argc, char **argv ) {
   testing::InitGoogleMock( &argc, argv );
   return RUN_ALL_TESTS();
 }
-

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -15,17 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-/*
- * iostream is included because there's a bug with python
- * earlier than 2.7.12 and 3.5.3 on OSX and FreeBSD.
- * When either no one else is using earlier versions of python
- * or ycmd drops support for those, this include statement can be removed.
- * Needs to be the absolute first header, so that it is imported
- * before anything python related.
- */
-#include <iostream>
-#include <pybind11/stl_bind.h>
-
 #include "CodePoint.h"
 #include "IdentifierCompleter.h"
 #include "PythonSupport.h"
@@ -42,6 +31,8 @@
 #  include "CompilationDatabase.h"
 #  include "Documentation.h"
 #endif // USE_CLANG_COMPLETER
+
+#include <pybind11/stl_bind.h>
 
 namespace py = pybind11;
 using namespace YouCompleteMe;


### PR DESCRIPTION
We don't need the `iostream` workaround with pybind11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bstaletic/ycmd/6)
<!-- Reviewable:end -->
